### PR TITLE
Fixes for Clang compilation and building on ARM64

### DIFF
--- a/examples/fec_test.c
+++ b/examples/fec_test.c
@@ -9,12 +9,21 @@
 #include "../rs.h"
 
 #ifndef PROFILE
-static inline long long rdtsc(void)
+#ifdef __x86_64__
+static long long rdtsc(void)
 {
     unsigned long low, hi;
     asm volatile ("rdtsc" : "=d" (hi), "=a" (low));
     return ( (((long long)hi) << 32) | ((long long) low));
 }
+#elif __arm__
+static long long rdtsc(void)
+{
+    u64 val;
+    asm volatile("mrs %0, cntvct_el0" : "=r" (val));
+    return val;
+}
+#endif
 #endif
 
 /*

--- a/examples/simple-encoder.c
+++ b/examples/simple-encoder.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 
+#include <libgen.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/stat.h>

--- a/rs.c
+++ b/rs.c
@@ -545,12 +545,21 @@ void fec_init(void)
 
 
 #ifdef PROFILE
+#ifdef __x86_64__
 static long long rdtsc(void)
 {
     unsigned long low, hi;
     asm volatile ("rdtsc" : "=d" (hi), "=a" (low));
     return ( (((long long)hi) << 32) | ((long long) low));
 }
+#elif __arm__
+static long long rdtsc(void)
+{
+    u64 val;
+    asm volatile("mrs %0, cntvct_el0" : "=r" (val));
+    return val;
+}
+#endif
 
 void print_matrix1(gf* matrix, int nrows, int ncols) {
     int i, j;
@@ -687,7 +696,7 @@ reed_solomon* reed_solomon_new(int data_shards, int parity_shards) {
     assert(fec_initialized);
 
     do {
-        rs = RS_MALLOC(sizeof(reed_solomon));
+        rs = (reed_solomon*) RS_MALLOC(sizeof(reed_solomon));
         if(NULL == rs) {
             return NULL;
         }

--- a/test_rs.c
+++ b/test_rs.c
@@ -151,7 +151,7 @@ unsigned char* test_create_random(reed_solomon *rs, int data_size, int block_siz
     n = nr_blocks / rs->data_shards;
     nr_blocks += n * rs->parity_shards;
 
-    data = malloc(nr_blocks * block_size);
+    data = (unsigned char *) malloc(nr_blocks * block_size);
     for(i = 0; i < data_size; i++) {
         data[i] = (unsigned char)(random() % 255);
     }
@@ -724,7 +724,7 @@ void test_004(void) {
 
     //size = sizeof(text)/sizeof(char)-1;
     size = 1024*1024;
-    origin = malloc(size);
+    origin = (unsigned char *) malloc(size);
     //memcpy(origin, text, size);
     for(i = 0; i < size; i++) {
         origin[i] = (unsigned char)(random() % 255);
@@ -735,7 +735,7 @@ void test_004(void) {
     n = nrBlocks / dataShards;
     nrFecBlocks = n*parityShards;
     nrShards = nrBlocks + nrFecBlocks;
-    data = malloc(nrShards * blockSize);
+    data = (unsigned char *) malloc(nrShards * blockSize);
     memcpy(data, origin, size);
     memset(data + size, 0, nrShards*blockSize - size);
     printf("nrBlocks=%d nrFecBlocks=%d nrShards=%d n=%d left=%d\n", nrBlocks, nrFecBlocks, nrShards, n, nrShards*blockSize - size);


### PR DESCRIPTION
This now builds on an M1 Macbook Air (ARM64) with Clang

```
Apple clang version 12.0.5 (clang-1205.0.22.9)
Target: arm64-apple-darwin20.3.0
Thread model: posix
```

Test run looks good:

```
./a.out 
test_galois:
test_sub_matrix:
test_multiply:
test_inverse:
XXX pivot not found!
test_one_encoding:
test_one_decoding:
test_encoding:
test_reconstruct:
reach here means test all ok
benchmarkEncode:
10x2x10000, test_count=20000 millis=3184.942000 per_sec_in_bytes=1197728.958840MB/s
100x20x10000, test_count=200 millis=3264.086000 per_sec_in_bytes=1168687.732377MB/s
17x3x(1024*1024), test_count=200 millis=8897.555000 per_sec_in_bytes=1146382.348859MB/s
test_003:
golang output(example/test_rs.go):
 [[104 101] [108 108] [111 32] [119 111] [114 108] [100 32] [104 101] [108 108] [111 32] [119 111] [114 108] [100 32] 
[157 178] [83 31] [48 240] [254 93] [31 89] [151 184]]
c verion output:
104 101 108 108 111 32 119 111 114 108 100 32 104 101 108 108 
111 32 119 111 114 108 100 32 157 178 83 31 48 240 254 93 
31 89 151 184 
erased:hexlo wozld hello woryd 
fixed:hello world hello world 
```